### PR TITLE
Handle missing game canvas gracefully

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,16 @@ import 'babylonjs-gui';
 import { Game } from './game/Game';
 import { defaultConfig } from './config/gameConfig';
 
-const canvas = document.getElementById('game') as HTMLCanvasElement;
-const engine = new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true, doNotHandleContextLost: true });
+const canvas = document.getElementById('game');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  console.error("Canvas with id 'game' not found. Aborting initialization.");
+} else {
+  const engine = new BABYLON.Engine(canvas, true, {
+    preserveDrawingBuffer: true,
+    stencil: true,
+    doNotHandleContextLost: true,
+  });
 
-const game = new Game(engine, defaultConfig);
-game.start();
+  const game = new Game(engine, defaultConfig);
+  game.start();
+}


### PR DESCRIPTION
## Summary
- avoid starting the game when the `#game` canvas element is missing
- log an error instead of creating a Babylon engine without a canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72e4a09d0832b96210115f20e6991